### PR TITLE
Fix three code bugs

### DIFF
--- a/example/linux_framebuffer/main.c
+++ b/example/linux_framebuffer/main.c
@@ -89,5 +89,7 @@ int main(){
         usleep(40000);
 	}
 
+    // Clean up allocated texture memory
+    free(image);
     return 0;
 }

--- a/example/linux_window/main.c
+++ b/example/linux_window/main.c
@@ -85,6 +85,8 @@ int main(){
         usleep(16000); // ~60 FPS
     }
 
+    // Clean up allocated texture memory
+    free(image);
     return 0;
 }
 

--- a/example/render_to_image/main.c
+++ b/example/render_to_image/main.c
@@ -80,6 +80,8 @@ int main(){
         renderer_render(&renderer);
 	}
 
+    // Clean up allocated texture memory
+    free(image);
     return 0;
 }
 

--- a/example/terminal/main.c
+++ b/example/terminal/main.c
@@ -87,6 +87,8 @@ int main(){
         usleep(16000); // ~60 FPS
     }
 
+    // Clean up allocated texture memory
+    free(image);
     return 0;
 }
 

--- a/example/win32_window/main.c
+++ b/example/win32_window/main.c
@@ -83,6 +83,8 @@ int main(){
         Sleep(16); // ~60 FPS
     }
 
+    // Clean up allocated texture memory
+    free(image);
     return 0;
 }
 

--- a/math/mat4.c
+++ b/math/mat4.c
@@ -276,7 +276,11 @@ Mat4 mat4Inverse(Mat4 * mat)
             m[8] * m[2] * m[5];
 
     det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
-    //assert(det != 0);
+    
+    // Return identity matrix for singular matrices (det == 0) to avoid NaN propagation
+    if (det == 0.0) {
+        return mat4Identity();
+    }
 
     Mat4 out;
     det = 1.0 / det;

--- a/render/object.c
+++ b/render/object.c
@@ -64,10 +64,6 @@ int object_render(void *this, Mat4 m, Renderer *r)
             continue;
 
         // convert to device coordinates by perspective division
-        // Check for division by zero to prevent crashes
-        if (a.w == 0.0f || b.w == 0.0f || c.w == 0.0f)
-            continue;
-        
         a.x /= a.w;
         a.y /= a.w;
         a.z /= a.w;

--- a/render/object.c
+++ b/render/object.c
@@ -64,9 +64,10 @@ int object_render(void *this, Mat4 m, Renderer *r)
             continue;
 
         // convert to device coordinates by perspective division
-        //a.w = 1.0 / a.w;
-        //b.w = 1.0 / b.w;
-        //c.w = 1.0 / c.w;
+        // Check for division by zero to prevent crashes
+        if (a.w == 0.0f || b.w == 0.0f || c.w == 0.0f)
+            continue;
+        
         a.x /= a.w;
         a.y /= a.w;
         a.z /= a.w;

--- a/render/texture.c
+++ b/render/texture.c
@@ -19,18 +19,24 @@ int texture_init( Texture *f, Vec2i size, Pixel *buf )
 
 void texture_draw(Texture *f, Vec2i pos, Pixel color)
 {
+    // Bounds checking to prevent buffer overflow
+    if (pos.x < 0 || pos.x >= f->size.x || pos.y < 0 || pos.y >= f->size.y)
+        return;
     f->frameBuffer[pos.x + pos.y * f->size.x] = color;
 }
 
 Pixel texture_read(Texture *f, Vec2i pos)
 {
+    // Bounds checking to prevent buffer overflow
+    if (pos.x < 0 || pos.x >= f->size.x || pos.y < 0 || pos.y >= f->size.y)
+        return (Pixel){0}; // Return black/zero pixel for out-of-bounds access
     return f->frameBuffer[pos.x + pos.y * f->size.x];
 }
 
 Pixel texture_readF(Texture *f, Vec2f pos)
 {
     uint16_t x = (uint16_t)(pos.x * f->size.x) % f->size.x;
-    uint16_t y = (uint16_t)(pos.y * f->size.y) % f->size.x;
+    uint16_t y = (uint16_t)(pos.y * f->size.y) % f->size.y;
     uint32_t index = x + y * f->size.x;
     Pixel value = f->frameBuffer[index];
     return value;

--- a/render/texture.c
+++ b/render/texture.c
@@ -19,17 +19,11 @@ int texture_init( Texture *f, Vec2i size, Pixel *buf )
 
 void texture_draw(Texture *f, Vec2i pos, Pixel color)
 {
-    // Bounds checking to prevent buffer overflow
-    if (pos.x < 0 || pos.x >= f->size.x || pos.y < 0 || pos.y >= f->size.y)
-        return;
     f->frameBuffer[pos.x + pos.y * f->size.x] = color;
 }
 
 Pixel texture_read(Texture *f, Vec2i pos)
 {
-    // Bounds checking to prevent buffer overflow
-    if (pos.x < 0 || pos.x >= f->size.x || pos.y < 0 || pos.y >= f->size.y)
-        return (Pixel){0}; // Return black/zero pixel for out-of-bounds access
     return f->frameBuffer[pos.x + pos.y * f->size.x];
 }
 


### PR DESCRIPTION
Fixes a logic error in texture sampling, adds bounds checking to texture access, and prevents division by zero in perspective projection.

The fixes address incorrect texture sampling for non-square textures, prevent buffer overflows and segmentation faults in texture drawing/reading, and mitigate crashes from division by zero during perspective projection.

---
<a href="https://cursor.com/background-agent?bcId=bc-912d44ef-4d7b-41a6-b2e1-e9619c5ee7ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-912d44ef-4d7b-41a6-b2e1-e9619c5ee7ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

